### PR TITLE
fix: specify maven project by default to fix e2e tests

### DIFF
--- a/test/helpers/test.go
+++ b/test/helpers/test.go
@@ -109,6 +109,7 @@ type TestOptions struct {
 	ApplicationName string
 	Organisation    string
 	JavaVersion     string
+	ProjectType     string
 }
 
 func AssignWorkDirValue(generatedWorkDir string) {

--- a/test/suite/spring/jx_create_spring.go
+++ b/test/suite/spring/jx_create_spring.go
@@ -13,20 +13,19 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var (
-	SkipManualPromotion = os.Getenv("JX_BDD_SKIP_MANUAL_PROMOTION")
-)
+var SkipManualPromotion = os.Getenv("JX_BDD_SKIP_MANUAL_PROMOTION")
 
 var _ = Describe("create spring\n", func() {
 	var T SpringTestOptions
 
 	BeforeEach(func() {
 		T = SpringTestOptions{
-
 			helpers.TestOptions{
 				ApplicationName: helpers.TempDirPrefix + "spring-" + strconv.FormatInt(GinkgoRandomSeed(), 10),
 				WorkDir:         helpers.WorkDir,
+				// ToDo(@ankitm123): parametrize this instead of hardcoding this
 				JavaVersion:     "11",
+				ProjectType:     "maven-project",
 			},
 		}
 		T.GitProviderURL()
@@ -35,7 +34,7 @@ var _ = Describe("create spring\n", func() {
 	Describe("Given valid parameters", func() {
 		Context("when running jx create spring", func() {
 			It("creates a spring application and promotes it to staging\n", func() {
-				args := []string{"project", "spring", "-b", "--org", T.GetGitOrganisation(), "--artifact", T.ApplicationName, "--name", T.ApplicationName, "-j", T.JavaVersion, "-d", "web", "-d", "actuator"}
+				args := []string{"project", "spring", "-b", "--org", T.GetGitOrganisation(), "--artifact", T.ApplicationName, "--name", T.ApplicationName, "-j", T.JavaVersion, "-d", "web", "-d", "actuator", "--type", T.ProjectType}
 
 				gitProviderUrl, err := T.GitProviderURL()
 				Expect(err).NotTo(HaveOccurred())


### PR DESCRIPTION
Signed-off-by: ankitm123 <ankitmohapatra123@gmail.com>

Seems like the default was set to gradle-project a few days back (upstream spring starter project, not jx). This is breaking our e2e tests.